### PR TITLE
 Add terraform module `vm` 

### DIFF
--- a/modules/vm/README.md
+++ b/modules/vm/README.md
@@ -1,0 +1,96 @@
+# VM
+Terraform module for Azure resource provisioning
+
+-----
+
+### Purpose
+
+Module `vm` pairs with module `network` to do the following:
+  - provision a variable amount of VMs within the input subnet
+  - modifiable disk sizes, VM sizes, images, etc.
+  - optional public IPs for the VMs
+  - optional list of additional security rules for the VMs
+  - optional list of role assignments for the VMs
+  - optional list of storage disks for the VMs
+
+-----
+
+### Example Usage
+
+```
+module "network" {
+  source = "./modules/network"
+
+  name                = "projectX"
+  env                 = "prod"
+  vnet_cidr           = "10.0.0.0/16"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+
+  bastion_node_image = {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-LTS"
+    version   = "latest"
+  }
+
+  ssh_public_key  = "../secret/ssh-user.pub"
+  ssh_private_key = "../secret/ssh-user"
+}
+
+module "vm" {
+  source = "./modules/vm"
+
+  name    = "projectX"
+  env     = "prod"
+  vm_name = "gitlab"
+
+  vm_image = {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-LTS"
+    version   = "latest"
+  }
+
+  resource_group_name         = "${azurerm_resource_group.main.name}"
+  subnet_id                   = "${module.network.subnet_id}"
+  network_security_group_name = "${module.network.main_network_security_group_name}"
+  bastion_ip                  = "${module.network.bastion_public_ip[0]}"
+  vm_count                    = 3
+  vm_size                     = "Standard_D2s_v3"
+  storage_os_disk_size        = 50
+  enable_public_ip            = true
+
+  security_rules = [
+    {
+      name                   = "inbound-ssh"
+      priority               = 100
+      direction              = "Inbound"
+      access                 = "Allow"
+      protocol               = "Tcp"
+      source_port_range      = "*"
+      destination_port_range = "22"
+      source_address_prefix  = "*"
+    },
+  ]
+
+  role_assignments = [
+    {
+      scope                = "${azurerm_resource_group.main.id}"
+      role_definition_name = "AcrPush"
+    },
+    {
+      scope                = "${azurerm_resource_group.main.id}"
+      role_definition_name = "AcrPull"
+    },
+  ]
+
+  vm_disks = [
+    {
+      storage_account_type = "StandardSSD_LRS"
+      disk_size_gb         = 100
+    },
+  ]
+  ssh_public_key  = "../secret/ssh-user.pub"
+  ssh_private_key = "../secret/ssh-user"
+}
+```

--- a/modules/vm/input.tf
+++ b/modules/vm/input.tf
@@ -1,0 +1,100 @@
+data "azurerm_resource_group" "main" {
+  name = "${var.resource_group_name}"
+}
+
+data "azurerm_network_security_group" "main" {
+  name                = "${var.network_security_group_name}"
+  resource_group_name = "${var.resource_group_name}"
+}
+
+variable "name" {
+  description = "name of the project"
+  type        = "string"
+}
+
+variable "env" {
+  description = "name of the environment"
+  type        = "string"
+}
+
+variable "resource_group_name" {
+  description = "name of the azurerm_resource_group to use"
+  type        = "string"
+}
+
+variable "subnet_id" {
+  description = "ID of the subnet into which to create VMs"
+  type        = "string"
+}
+
+variable "network_security_group_name" {
+  description = "name of the network security group associated with the subnet corresponding to subnet_id"
+  type        = "string"
+}
+
+variable "enable_public_ip" {
+  description = "set to true (boolean) to provision and associate public IP addresses with the created VMs"
+  type        = "string"
+  default     = false
+}
+
+variable "security_rules" {
+  description = "list of maps representing security rules (name, priority, direction, access, protocol, source_port_range, destination_port_range, source_address_prefix) to be applied to the created VMs"
+  type        = "list"
+  default     = []
+}
+
+variable "role_assignments" {
+  description = "list of maps representing role assignments (scope, role_definition_name) to be applied to the created VMs"
+  type        = "list"
+  default     = []
+}
+
+variable "vm_name" {
+  description = "name of the VM group (e.g. build)"
+  type        = "string"
+}
+
+variable "vm_count" {
+  description = "number of VMs to create"
+  type        = "string"
+  default     = 1
+}
+
+variable "vm_image" {
+  description = "VM image - must contain mappings for string-keys (publisher, offer, sku, version)"
+  type        = "map"
+}
+
+variable "vm_size" {
+  description = "VM type (e.g. Standard_B1ms)"
+  type        = "string"
+}
+
+variable "storage_os_disk_size" {
+  description = "number indicating the size of the storage disk of the created VMs in gigabytes"
+  type        = "string"
+  default     = 80
+}
+
+variable "vm_disks" {
+  description = "list of maps representing managed disks (storage_account_type, disk_size_gb) that are to be created and attached to the created VMs"
+  type        = "list"
+  default     = []
+}
+
+variable "bastion_ip" {
+  description = "bastion IP address"
+  type        = "string"
+  default     = ""
+}
+
+variable "ssh_public_key" {
+  description = "local path to the authorized SSH public key to connect to the created VMs"
+  type        = "string"
+}
+
+variable "ssh_private_key" {
+  description = "local path to the authorized SSH private key to connect to the created VMs"
+  type        = "string"
+}

--- a/modules/vm/output.tf
+++ b/modules/vm/output.tf
@@ -1,0 +1,21 @@
+locals {
+  inventory = <<EOF
+[${var.vm_name}]
+${join("\n", formatlist("%s ansible_host=%s", azurerm_virtual_machine.vm.*.name, coalescelist(azurerm_public_ip.vm.*.ip_address, azurerm_network_interface.vm.*.private_ip_address)))}
+
+[${var.vm_name}:vars]
+ansible_user=ubuntu
+${var.bastion_ip != "" ? "${local.ansible_ssh_common_args}" : ""}
+${var.ssh_private_key != "" ? "ansible_ssh_private_key_file=${var.ssh_private_key}" : ""}
+EOF
+}
+
+locals {
+  ansible_ssh_common_args = <<EOF
+ansible_ssh_common_args='-o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p -q ${var.ssh_private_key != "" ? "-i ${var.ssh_private_key}" : ""} ubuntu@${var.bastion_ip}"'
+EOF
+}
+
+output "inventory" {
+  value = "${local.inventory}"
+}

--- a/modules/vm/vm.tf
+++ b/modules/vm/vm.tf
@@ -1,0 +1,112 @@
+resource "azurerm_public_ip" "vm" {
+  count               = "${var.enable_public_ip ? var.vm_count : 0}"
+  name                = "${var.name}-${var.env}-${var.vm_name}-${count.index+1}"
+  location            = "${data.azurerm_resource_group.main.location}"
+  resource_group_name = "${data.azurerm_resource_group.main.name}"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_network_interface" "vm" {
+  count                     = "${var.vm_count}"
+  name                      = "${var.name}-${var.env}-${var.vm_name}-${count.index+1}"
+  location                  = "${data.azurerm_resource_group.main.location}"
+  resource_group_name       = "${data.azurerm_resource_group.main.name}"
+  network_security_group_id = "${data.azurerm_network_security_group.main.id}"
+
+  ip_configuration {
+    name                          = "${var.name}-${var.env}-${var.vm_name}-${count.index+1}"
+    subnet_id                     = "${var.subnet_id}"
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = "${var.enable_public_ip ? element(concat(azurerm_public_ip.vm.*.id, list("")), var.enable_public_ip * count.index) : ""}" #hacky workaround
+  }
+}
+
+resource "azurerm_virtual_machine" "vm" {
+  count                 = "${var.vm_count}"
+  name                  = "${var.name}-${var.env}-${var.vm_name}-${count.index+1}"
+  location              = "${data.azurerm_resource_group.main.location}"
+  resource_group_name   = "${data.azurerm_resource_group.main.name}"
+  network_interface_ids = ["${azurerm_network_interface.vm.*.id[count.index]}"]
+  vm_size               = "${var.vm_size}"
+
+  delete_os_disk_on_termination = true
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  storage_image_reference {
+    publisher = "${var.vm_image["publisher"]}"
+    offer     = "${var.vm_image["offer"]}"
+    sku       = "${var.vm_image["sku"]}"
+    version   = "${var.vm_image["version"]}"
+  }
+
+  storage_os_disk {
+    name              = "${var.name}-${var.env}-${var.vm_name}-${count.index+1}"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+    disk_size_gb      = "${var.storage_os_disk_size}"
+  }
+
+  os_profile {
+    computer_name  = "${var.name}-${var.env}-${var.vm_name}-${count.index+1}"
+    admin_username = "ubuntu"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+
+    ssh_keys {
+      key_data = "${file(var.ssh_public_key)}"
+      path     = "/home/ubuntu/.ssh/authorized_keys"
+    }
+  }
+}
+
+resource "azurerm_managed_disk" "vm" {
+  count                = "${length(var.vm_disks) * var.vm_count}"
+  name                 = "${var.name}-${var.env}-${var.vm_name}-${(count.index % var.vm_count) + 1}-${count.index + 1}"
+  location             = "${data.azurerm_resource_group.main.location}"
+  resource_group_name  = "${data.azurerm_resource_group.main.name}"
+  storage_account_type = "${lookup(var.vm_disks[count.index % length(var.vm_disks)], "storage_account_type")}"
+  create_option        = "Empty"
+  disk_size_gb         = "${lookup(var.vm_disks[count.index % length(var.vm_disks)], "disk_size_gb")}"
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "vm" {
+  count              = "${length(var.vm_disks) * var.vm_count}"
+  managed_disk_id    = "${azurerm_managed_disk.vm.*.id[count.index]}"
+  virtual_machine_id = "${azurerm_virtual_machine.vm.*.id[count.index % var.vm_count]}"
+  lun                = "${(count.index % length(var.vm_disks)) + 1}"
+  caching            = "ReadWrite"
+}
+
+resource "azurerm_role_assignment" "vm" {
+  count                = "${length(var.role_assignments) * var.vm_count}"
+  scope                = "${lookup(var.role_assignments[count.index % length(var.role_assignments)], "scope")}"
+  role_definition_name = "${lookup(var.role_assignments[count.index % length(var.role_assignments)], "role_definition_name")}"
+  principal_id         = "${element(azurerm_virtual_machine.vm.*.identity.0.principal_id, count.index % var.vm_count)}"
+}
+
+resource "azurerm_network_security_rule" "vm" {
+  count                  = "${length(var.security_rules) * var.vm_count}"
+  name                   = "${var.name}-${var.env}-${var.vm_name}-${(count.index % var.vm_count) + 1}-${count.index + 1}-${lookup(var.security_rules[count.index % length(var.security_rules)], "name")}"
+  priority               = "${lookup(var.security_rules[count.index % length(var.security_rules)], "priority") + count.index + 1}"
+  direction              = "${lookup(var.security_rules[count.index % length(var.security_rules)], "direction")}"
+  access                 = "${lookup(var.security_rules[count.index % length(var.security_rules)], "access")}"
+  protocol               = "${lookup(var.security_rules[count.index % length(var.security_rules)], "protocol")}"
+  source_port_range      = "${lookup(var.security_rules[count.index % length(var.security_rules)], "source_port_range")}"
+  destination_port_range = "${lookup(var.security_rules[count.index % length(var.security_rules)], "destination_port_range")}"
+  source_address_prefix  = "${lookup(var.security_rules[count.index % length(var.security_rules)], "source_address_prefix")}"
+
+  destination_address_prefixes = [
+    "${compact(list(azurerm_network_interface.vm.*.private_ip_address[count.index % var.vm_count],
+    var.enable_public_ip ? element(concat(azurerm_public_ip.vm.*.ip_address,
+    list("")), var.enable_public_ip * (count.index % var.vm_count)) : ""))}",
+  ] # hacky workaround
+
+  resource_group_name         = "${var.resource_group_name}"
+  network_security_group_name = "${var.network_security_group_name}"
+}


### PR DESCRIPTION
Module `vm` pairs with module `network` to do the following:
 - provision a variable amount of VMs within the input subnet
 - modifiable disk sizes, VM sizes, images, etc.
 - optional public IPs for the VMs
 - optional list of additional security rules for the VMs
 - optional list of role assignments for the VMs
 - optional list of storage disks for the VMs

See `README.md` for additional documentation

@lnovara 